### PR TITLE
Fixed audit log typo when changing news visibility

### DIFF
--- a/app/Http/Controllers/AdminDash.php
+++ b/app/Http/Controllers/AdminDash.php
@@ -898,7 +898,7 @@ class AdminDash extends Controller
           $audit = new Audit;
           $audit->cid = Auth::id();
           $audit->ip = $_SERVER['REMOTE_ADDR'];
-          $audit->what = Auth::user()->full_name . ' made \"' . $calendar->title . '\" ' . $type . '.';
+          $audit->what = Auth::user()->full_name . ' made ' . $calendar->title . ' ' . $type . '.';
           $audit->save();
 
             return redirect('/dashboard/admin/calendar')->with('success', 'Changed ' . $calendar->title . ' to be ' . $type . '!');


### PR DESCRIPTION
Fixed simple typo, would show as `NAME made \"News Name\" visible` now will show as `NAME made News Name visible`.